### PR TITLE
fix: Ocp maps/refactor naming

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,3 +1,3 @@
 version: 1
 
-module_version: 0.3.3
+module_version: 0.3.4

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,3 +1,3 @@
 version: 1
 
-module_version: 0.3.2
+module_version: 0.3.3

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ locals {
   )
 
   # Use `local.vpc_id` to give a hint to Terraform that subnets should be deleted before secondary CIDR blocks can be free!
-  vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc_ipv4_cidr_block_association.ipam[0].vpc_id, aws_vpc.this[0].id, "")
+  vpc_id     = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc_ipv4_cidr_block_association.ipam[0].vpc_id, aws_vpc.this[0].id, "")
   create_vpc = var.create_vpc && var.putin_khuylo
 }
 
@@ -127,7 +127,7 @@ resource "aws_subnet" "public" {
         var.public_subnet_names[count.index],
         format("%s-%s%s-%s-sub-%s", var.name_prefix, var.short_aws_region,
           substr(element(var.azs, count.index), -1, 1),
-          lookup(var.az_name_to_az_id, element(var.azs, count.index), ""),
+          lookup(local.az_name_to_az_id, element(var.azs, count.index), ""),
           var.public_subnet_suffix
         )
       )
@@ -269,7 +269,7 @@ resource "aws_subnet" "private" {
         var.private_subnet_names[count.index],
         format("%s-%s%s-%s-sub-%s", var.name_prefix, var.short_aws_region,
           substr(element(var.azs, count.index), -1, 1),
-          lookup(var.az_name_to_az_id, element(var.azs, count.index), ""),
+          lookup(local.az_name_to_az_id, element(var.azs, count.index), ""),
           var.private_subnet_suffix
         )
       )
@@ -396,7 +396,7 @@ resource "aws_subnet" "database" {
         format(
           "%s-%s%s-%s-sub-%s", var.name_prefix, var.short_aws_region,
           substr(element(var.azs, count.index), -1, 1),
-          lookup(var.az_name_to_az_id, element(var.azs, count.index), ""),
+          lookup(local.az_name_to_az_id, element(var.azs, count.index), ""),
           var.database_subnet_suffix
         )
       )
@@ -586,7 +586,7 @@ resource "aws_subnet" "redshift" {
         var.redshift_subnet_names[count.index],
         format("${var.name_prefix}-${var.short_aws_region}%s-%s-sub-${var.redshift_subnet_suffix}",
           substr(element(var.azs, count.index), -1, 1),
-          lookup(var.az_name_to_az_id, element(var.azs, count.index), "")
+          lookup(local.az_name_to_az_id, element(var.azs, count.index), "")
         )
       )
     },
@@ -726,7 +726,7 @@ resource "aws_subnet" "elasticache" {
         var.elasticache_subnet_names[count.index],
         format("%s-%s%s-%s-sub-%s", var.name_prefix, var.short_aws_region,
           substr(element(var.azs, count.index), -1, 1),
-          lookup(var.az_name_to_az_id, element(var.azs, count.index), ""),
+          lookup(local.az_name_to_az_id, element(var.azs, count.index), ""),
           var.elasticache_subnet_suffix
         )
       )
@@ -859,7 +859,7 @@ resource "aws_subnet" "intra" {
         var.intra_subnet_names[count.index],
         format("%s-%s%s-%s-sub-%s", var.name_prefix, var.short_aws_region,
           substr(element(var.azs, count.index), -1, 1),
-          lookup(var.az_name_to_az_id, element(var.azs, count.index), ""),
+          lookup(local.az_name_to_az_id, element(var.azs, count.index), ""),
           var.intra_subnet_suffix
         )
       )

--- a/tgw.tf
+++ b/tgw.tf
@@ -1,3 +1,16 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  az_name_to_az_id = {
+    for az in data.aws_availability_zones.available.names : az =>
+    split("-", element(data.aws_availability_zones.available.zone_ids,
+      index(data.aws_availability_zones.available.names, az))
+    )[1]
+  }
+}
+
 ################################################################################
 # TGW Subnets
 ################################################################################
@@ -33,8 +46,8 @@ resource "aws_subnet" "tgw" {
           "%s-%s%s-%s-sub-%s",
           var.name_prefix,
           var.short_aws_region,
-          substr(element(var.azs, count.index), -1, 1),                    # Get last letter of az code
-          lookup(var.az_name_to_az_id, element(var.azs, count.index), ""), # Lookup az-id based on name
+          substr(element(var.azs, count.index), -1, 1),                      # Get last letter of az code
+          lookup(local.az_name_to_az_id, element(var.azs, count.index), ""), # Lookup az-id based on name
           var.tgw_subnet_suffix
         )
       )

--- a/variables.tf
+++ b/variables.tf
@@ -55,12 +55,6 @@ variable "azs" {
   default     = []
 }
 
-variable "az_name_to_az_id" {
-  description = "A map of availability zones names to ids in the account"
-  type        = map(string)
-  default     = {}
-}
-
 variable "enable_dns_hostnames" {
   description = "Should be true to enable DNS hostnames in the VPC"
   type        = bool


### PR DESCRIPTION
Change from input variable to local for naming AZ IDs