### PR TITLE
[fix] Fix maps3 v1.0.0 when the variable is non_web_traffic_subnet is not enable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "aws_subnet" "public" {
 }
 
 locals {
-  num_public_route_tables = local.create_gwlb ? local.len_public_subnets : 1
+  num_public_route_tables = local.len_public_subnets
 }
 
 resource "aws_route_table" "public" {


### PR DESCRIPTION
I found a case not covered by our tests and namely when:
```
  non_web_traffic_subnet:
    enabled: false
```
